### PR TITLE
Explode less

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sentryR
 Type: Package
 Title: Send Errors and Messages to Sentry
-Version: 1.1.1
+Version: 1.2.0
 Authors@R: c(
   person("Joao", "Santiago", email = "santiago@billie.io", role = c("aut", "cre")),
   person("Daniel", "Kirsch", role = "aut", email = "daniel@billie.io"),

--- a/R/core.R
+++ b/R/core.R
@@ -228,7 +228,8 @@ prepare_payload <- function(...) {
 #' }
 capture <- function(...) {
   if (!is_sentry_configured()) {
-    stop("Sentry is not configured!")
+    warning("Sentry is not configured. Nothing was reported!")
+    return()
   }
 
   payload <- prepare_payload(...)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,4 +5,4 @@
 # FIXME: should use utils::packageVersion() instead, but that's not working
 # with CRAN because the package is checked before being installed, thus there is
 # no sentryR package to get the version from
-.sentry_env$pkg_version <- "1.0.0"
+.sentry_env$pkg_version <- "1.2.0"


### PR DESCRIPTION
`stop()`ing when sentry is not configured proved to harsh in real life.
Sometimes we want to test an api without configuring sentry.
In these cases, sentryr should acknowledge it was called, but gracefully return control