### PR TITLE
Fix stack reference subsetting

### DIFF
--- a/R/calls.R
+++ b/R/calls.R
@@ -4,49 +4,25 @@
 #'
 #' @return a data.frame
 calls_to_stacktrace <- function(calls) {
+  # note, attr(NULL, ...) is NULL
   srcrefs <- lapply(calls, function(call) attr(call, "srcref", exact = TRUE))
-  srcfiles <- lapply(srcrefs, function(ref) {
-    if (!is.null(ref)) {
-      attr(ref, "srcfile", exact = TRUE)
-    }
-  })
-
-  # https://github.com/rstudio/shiny/blob/master/R/conditions.R#L64
-  funs <- sapply(calls, function(call) {
-    if (is.function(call[[1]])) {
-      "<Anonymous>"
-    } else if (inherits(call[[1]], "call")) {
-      paste0(format(call[[1]]), collapse = " ")
-    } else if (typeof(call[[1]]) == "promise") {
-      "<Promise>"
-    } else {
-      paste0(as.character(call[[1]]), collapse = " ")
-    }
-  })
-
-  # drop calls to uninformative error handling internals, as in
-  # https://github.com/rstudio/shiny/blob/master/R/conditions.R#L399
-  to_keep <- !(funs %in%
-    c(".handleSimpleError", "h", "doTryCatch", "tryCatchList", "tryCatchOne")
-  )
-
-  funs_to_keep <- funs[to_keep]
-
-  names(srcrefs) <- funs_to_keep
-  names(srcfiles) <- funs_to_keep
-
-  srcrefs <- srcrefs[to_keep]
-
-  srcfiles <- srcfiles[to_keep]
-
-  full_function_call <- as.character(calls)
-  names(full_function_call) <- funs_to_keep
-  full_function_call <- full_function_call[to_keep]
+  srcfiles <- lapply(srcrefs, function(ref) attr(ref, "srcfile", exact = TRUE))
 
   # TODO: Offset the lines to the function definition, not the function call
   df <- tibble::tibble(
-    `function` = funs_to_keep,
-    raw_function = full_function_call,
+    `function` = sapply(calls, function(call) {
+      # https://github.com/rstudio/shiny/blob/master/R/conditions.R#L64
+      if (is.function(call[[1]])) {
+        "<Anonymous>"
+      } else if (inherits(call[[1]], "call")) {
+        paste0(format(call[[1]]), collapse = " ")
+      } else if (typeof(call[[1]]) == "promise") {
+        "<Promise>"
+      } else {
+        paste0(as.character(call[[1]]), collapse = " ")
+      }
+    }),
+    raw_function = as.character(calls),
     module = vapply(srcfiles, function(file) {
       if (!is.null(file$original)) {
         return(basename(file$original$filename))
@@ -74,7 +50,7 @@ calls_to_stacktrace <- function(calls) {
         return(file$lines[[line]])
       }
       return(NA_character_)
-    }, srcfiles, lineno)),
+    }, srcfiles, lineno, SIMPLIFY = FALSE)),
     pre_context = mapply(function(file, line) {
       if (!is.null(file)) {
         # 5 line window is recommended by Sentry
@@ -88,7 +64,7 @@ calls_to_stacktrace <- function(calls) {
         return(file$lines[start_line:(line - 1)])
       }
       return(NA_character_)
-    }, srcfiles, lineno),
+    }, srcfiles, lineno, SIMPLIFY = FALSE),
     post_context = mapply(function(file, line) {
       if (!is.null(file)) {
         if (!is.null(file$original)) {
@@ -98,8 +74,22 @@ calls_to_stacktrace <- function(calls) {
         return(file$lines[(line + 1):(line + 5)])
       }
       return(NA_character_)
-    }, srcfiles, lineno)
+    }, srcfiles, lineno, SIMPLIFY = FALSE)
   )
+
+  # Remove "boring" calls within internal error handling functions,
+  # as in https://github.com/rstudio/shiny/blob/master/R/conditions.R#L399
+  do_keep <- !(df$`function` %in%
+    c(".handleSimpleError", "h", "doTryCatch", "tryCatchList", "tryCatchOne")
+  )
+  df <- df[do_keep, ]
+
+  # Name the vector elements of each column by the bare function name
+  for (col in colnames(df)) {
+    if (col != "function") {
+      names(df[[col]]) <- df$`function`
+    }
+  }
 
   df
 }


### PR DESCRIPTION
This is a resubmission of https://github.com/jcpsantiago/sentryR/pull/29 from a new repo (since the previous repo has been frozen after its owning company folded).

- builds a stack tibble, then removes "boring" functions, to make sure everything stays aligned
- adds simplify = FALSE to fix a buglet with very short stacks
- adds a test case for call stack conversion

Fixes https://github.com/jcpsantiago/sentryR/issues/25